### PR TITLE
Update dependency: pi-topd-extra -> pi-topd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -101,7 +101,7 @@ Architecture: all
 Depends:
  ${misc:Depends},
 # Desktop components of desktop support
- pi-topd-extra,
+ pi-topd,
 # systemd services
  pt-os-notify-services,
 # Only suggested by device manager to support headless configurations


### PR DESCRIPTION
Updated dependency due to issues when building `pi-topd`.