### PR TITLE
Add wpagui to pt-os-apps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -92,6 +92,7 @@ Recommends:
  sonic-pi,
  touche,
  vlc,
+ wpagui,
 Description: pi-topOS Applications
  This package contains the files and dependencies required
  to install and configure pi-topOS' GUI applications.

--- a/debian/control
+++ b/debian/control
@@ -93,6 +93,9 @@ Recommends:
  touche,
  vlc,
  wpagui,
+Conflicts:
+# menu is recommended by wpa_gui and makes unwanted additions to the start menu
+ menu,
 Description: pi-topOS Applications
  This package contains the files and dependencies required
  to install and configure pi-topOS' GUI applications.


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [Ticket](https://pi-top.atlassian.net/browse/SWE-3) |


#### Main changes
- Adds wpagui (package for command wpa_gui) to pt-os-apps. This is something we'd like to use in the wpa2 enterprise config instructions, as an alternative to editing wpa_supplicant.conf directly

#### Tag anyone who definitely needs to review or help
- @jcapona 
