### PR TITLE
Update path to recovery partition

### DIFF
--- a/usr/lib/pt-os-notify-services/pt-eeprom
+++ b/usr/lib/pt-os-notify-services/pt-eeprom
@@ -69,13 +69,15 @@ force_conf_entry() {
 
 set_eeprom_installation_directory() {
   bootfs_entry="/boot"
-  [[ -d "/recovery" ]] && bootfs_entry="/recovery"
+  [[ -d "/boot/.recovery" ]] && bootfs_entry="/boot/.recovery"
   force_conf_entry BOOTFS "${bootfs_entry}" "/etc/default/rpi-eeprom-update"
 }
 
 patch_eeprom() {
+  echo "Patching EEPROM configuration"
   force_conf_entry WAKE_ON_GPIO 0 "${tmp_dir}/boot.conf"
   force_conf_entry POWER_OFF_ON_HALT 1 "${tmp_dir}/boot.conf"
+  echo "Applying EEPROM configuration"
   rpi-eeprom-config --apply "${tmp_dir}/boot.conf"
 }
 
@@ -108,12 +110,10 @@ set_eeprom_installation_directory
 if board_revision_requires_patched_eeprom; then
   echo "Board revision requires patched EEPROM"
   read_eeprom_settings
-  if eeprom_needs_patching; then
-    if [ -z $force ]; then
-      show_notification
-    else
-      patch_eeprom
-    fi
+  if [ -n "${force}" ]; then
+    patch_eeprom
+  elif eeprom_needs_patching; then
+    show_notification
   else
     echo "EEPROM does not require patching - doing nothing"
   fi


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [Ticket](https://pi-top.atlassian.net/browse/OS-1226) |


#### Main changes
- Update path to recovery partition; on bullseye it's on `/boot/.recovery`.
- Updated script logic to actually force an EEPROM parameter update when the `-f` parameter is provided.

#### Screenshots (feature, test output, profiling, dev tools etc)

N/A

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
N/A

#### Manual testing tips

- Download and unzip PR artifacts. You only need the package `pt-os-notify-services` (eg: file should be something like `pt-os-notify-services_5.4.0-4~2.gbped8d18_all.deb`)
- scp the file into your pi-top
- Install it with `sudo apt install ./*.deb`

Take notes of your current EEPROM configuration with `rpi-eeprom-config`:
```
pi@pi-top:~ $ rpi-eeprom-config
BOOT_UART=0
WAKE_ON_GPIO=0
```
And your current EEPROM version with `rpi-eeprom-update`:
```
pi@pi-top:~ $ rpi-eeprom-update
*** UPDATE AVAILABLE ***
BOOTLOADER: update available
   CURRENT: Thu 01 Jan 1970 12:00:00 AM UTC (0)
    LATEST: Tue 25 Jan 2022 02:30:41 PM UTC (1643121041)
   RELEASE: default (/lib/firmware/raspberrypi/bootloader/default)
            Use raspi-config to change the release.

  VL805_FW: Dedicated VL805 EEPROM
     VL805: version unknown. Try sudo rpi-eeprom-update
   CURRENT:
    LATEST: 000138a1
```

There are several ways to test this.

1. The first way to test would be to run `sudo systemctl restart pt-eeprom-manager`, which should display a notification in case your EEPROM needs patching. You won't see anything in case your EEPROM doesn't need it. If you do get a notification, it should display a button. Don't press it since you would miss all the logs.

2. Another way would be to install this package in a not-yet-onboarded pi-top and make sure that the EEPROM is properly updated in the reboot page. This should fix some of the poweroff/restart issues we've been having.

3. The last one, and the one I think we should actually test, is to run the command that the notification button from test case (1) and the onboarding restart page in test case (2) use, which is `/usr/lib/pt-os-notify-services/pt-eeprom -f`. This will force a EEPROM patch & update. You can run this command directly in your pi-top:

```
pi@pi-top:~ $ sudo /usr/lib/pt-os-notify-services/pt-eeprom -f
Board revision requires patched EEPROM
Patching EEPROM configuration
Applying EEPROM configuration
Updating bootloader EEPROM
 image: /lib/firmware/raspberrypi/bootloader/default/pieeprom-2022-01-25.bin
config_src: /tmp/tmp.7l4TuLxngy/boot.conf
config: /tmp/tmp.7l4TuLxngy/boot.conf
################################################################################
BOOT_UART=0

WAKE_ON_GPIO=0
POWER_OFF_ON_HALT=1

################################################################################

*** To cancel this update run 'sudo rpi-eeprom-update -r' ***

*** INSTALLING /tmp/tmpx49h4nve/pieeprom.upd  ***

   CURRENT: Thu 29 Apr 2021 04:11:25 PM UTC (1619712685)
    UPDATE: Tue 25 Jan 2022 02:30:41 PM UTC (1643121041)
    BOOTFS: /boot/.recovery

EEPROM updates pending. Please reboot to apply the update.
To cancel a pending update run "sudo rpi-eeprom-update -r".
```

This will setup an EEPROM update for next boot. As the command says, you can cancel this by running `sudo rpi-eeprom-update -r`.

If you reboot, you should get the updated EEPROM, which you can verify with `rpi-eeprom-update`.

#### Tag anyone who definitely needs to review or help
N/A
