### PR TITLE
pt-os-apps depends on python3-godirect

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -95,6 +95,7 @@ Recommends:
  mtpaint,
  mu-editor,
  python3-grove.py,
+ python3-godirect,
  python3-minecraftpi,
  realvnc-vnc-viewer,
  scratch3,


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1407) |


#### Main changes
`pt-os-apps` depends on `python3-godirect`, providing support for VernierST devices.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
